### PR TITLE
Refactor core modules

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,7 +1,6 @@
 import nextcord
 from nextcord.ext import commands
 import logging
-import asyncio
 import os
 from db.database import setup_db
 from dotenv import load_dotenv
@@ -10,7 +9,12 @@ load_dotenv()
 TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 
 # Logging
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", filename="bot.log", filemode="a")
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    filename="bot.log",
+    filemode="a",
+)
 
 # Intents
 intents = nextcord.Intents.default()
@@ -21,6 +25,7 @@ intents.message_content = True
 
 # Bot setup
 bot = commands.AutoShardedBot(command_prefix="!", intents=intents)
+
 
 @bot.event
 async def on_ready():
@@ -43,10 +48,12 @@ async def on_ready():
     except Exception as e:
         print(f"❌ Failed to sync commands: {e}")
 
+
 @bot.event
 async def on_command_error(ctx, error):
     await ctx.send(f"❗ เกิดข้อผิดพลาด: {error}")
     logging.exception("Command Error: %s", str(error))
+
 
 if __name__ == "__main__":
     bot.run(TOKEN)

--- a/game/game_state.py
+++ b/game/game_state.py
@@ -1,23 +1,28 @@
 def check_winner(board: str):
-  """
-  รับบอร์ด XO (เช่น 'XOXOX--O-') แล้วคืนผล:
-  - 'X' หรือ 'O' → มีผู้ชนะ
-  - 'draw' → เสมอ
-  - None → ยังไม่จบเกม
-  """
+    """
+    รับบอร์ด XO (เช่น 'XOXOX--O-') แล้วคืนผล:
+    - 'X' หรือ 'O' → มีผู้ชนะ
+    - 'draw' → เสมอ
+    - None → ยังไม่จบเกม
+    """
 
-  win_conditions = [
-      [0, 1, 2], [3, 4, 5], [6, 7, 8],  # แถว
-      [0, 3, 6], [1, 4, 7], [2, 5, 8],  # คอลัมน์
-      [0, 4, 8], [2, 4, 6]              # ทแยง
-  ]
+    win_conditions = [
+        [0, 1, 2],
+        [3, 4, 5],
+        [6, 7, 8],  # แถว
+        [0, 3, 6],
+        [1, 4, 7],
+        [2, 5, 8],  # คอลัมน์
+        [0, 4, 8],
+        [2, 4, 6],  # ทแยง
+    ]
 
-  for condition in win_conditions:
-      a, b, c = condition
-      if board[a] != '-' and board[a] == board[b] == board[c]:
-          return board[a]  # 'X' หรือ 'O'
+    for condition in win_conditions:
+        a, b, c = condition
+        if board[a] != "-" and board[a] == board[b] == board[c]:
+            return board[a]  # 'X' หรือ 'O'
 
-  if '-' not in board:
-      return 'draw'
+    if "-" not in board:
+        return "draw"
 
-  return None
+    return None

--- a/game/views.py
+++ b/game/views.py
@@ -1,14 +1,22 @@
-import nextcord
 from nextcord.ui import View, Button
 from nextcord import ButtonStyle, Interaction
-from db.database import update_board, get_game_state, end_game
+from db.database import update_board, end_game
 from game.game_state import check_winner
 import asyncio
 from datetime import datetime, timedelta
 from config import GAME_TIMEOUT_MINUTES
 
+
 class XOGameView(View):
-    def __init__(self, game_id: int, player_x: int, player_o: int, board: str, turn: str, start_time: str):
+    def __init__(
+        self,
+        game_id: int,
+        player_x: int,
+        player_o: int,
+        board: str,
+        turn: str,
+        start_time: str,
+    ):
         super().__init__(timeout=None)
         self.game_id = game_id
         self.player_x = player_x
@@ -23,19 +31,24 @@ class XOGameView(View):
     def build_buttons(self):
         self.clear_items()
         for idx in range(9):
-            label = self.board[idx] if self.board[idx] != '-' else '⬜'
-            style = ButtonStyle.green if self.board[idx] == 'X' else (
-                    ButtonStyle.red if self.board[idx] == 'O' else ButtonStyle.grey)
+            label = self.board[idx] if self.board[idx] != "-" else "⬜"
+            style = (
+                ButtonStyle.green
+                if self.board[idx] == "X"
+                else (ButtonStyle.red if self.board[idx] == "O" else ButtonStyle.grey)
+            )
             self.add_item(XOButton(idx, label, style))
 
     def get_time_left(self):
         elapsed = datetime.utcnow() - self.start_time
-        remaining = max(timedelta(minutes=GAME_TIMEOUT_MINUTES) - elapsed, timedelta(seconds=0))
+        remaining = max(
+            timedelta(minutes=GAME_TIMEOUT_MINUTES) - elapsed, timedelta(seconds=0)
+        )
         minutes, seconds = divmod(int(remaining.total_seconds()), 60)
         return f"{minutes} นาที {seconds} วินาที"
 
     def current_turn_display(self):
-        turn_user = f"<@{self.player_x}>" if self.turn == 'X' else f"<@{self.player_o}>"
+        turn_user = f"<@{self.player_x}>" if self.turn == "X" else f"<@{self.player_o}>"
         return f"""🎯 ตาของ {turn_user}
 ⏳ เวลาที่เหลือ: {self.get_time_left()}"""
 
@@ -44,10 +57,10 @@ class XOGameView(View):
             await msg.edit(content=self.current_turn_display(), view=self)
 
     async def end_game_display(self, winner):
-        if winner == 'X':
+        if winner == "X":
             result_msg = f"""🎉 <@{self.player_x}> ชนะ!
 😢 <@{self.player_o}> แพ้"""
-        elif winner == 'O':
+        elif winner == "O":
             result_msg = f"""🎉 <@{self.player_o}> ชนะ!
 😢 <@{self.player_x}> แพ้"""
         else:
@@ -74,27 +87,34 @@ class XOGameView(View):
     async def handle_move(self, interaction: Interaction, index: int):
         async with self.lock:
             current_player = interaction.user.id
-            if (self.turn == 'X' and current_player != self.player_x) or                (self.turn == 'O' and current_player != self.player_o):
-                await interaction.response.send_message("⛔ ไม่ใช่ตาของคุณ!", ephemeral=True)
+            if (self.turn == "X" and current_player != self.player_x) or (
+                self.turn == "O" and current_player != self.player_o
+            ):
+                await interaction.response.send_message(
+                    "⛔ ไม่ใช่ตาของคุณ!", ephemeral=True
+                )
                 return
 
-            if self.board[index] != '-':
-                await interaction.response.send_message("❗ ช่องนี้ถูกเลือกไปแล้ว!", ephemeral=True)
+            if self.board[index] != "-":
+                await interaction.response.send_message(
+                    "❗ ช่องนี้ถูกเลือกไปแล้ว!", ephemeral=True
+                )
                 return
 
             self.board[index] = self.turn
-            winner = check_winner(''.join(self.board))
+            winner = check_winner("".join(self.board))
 
             if winner:
                 await interaction.response.defer()
                 await self.end_game_display(winner)
                 return
 
-            self.turn = 'O' if self.turn == 'X' else 'X'
-            await update_board(self.game_id, ''.join(self.board), self.turn)
+            self.turn = "O" if self.turn == "X" else "X"
+            await update_board(self.game_id, "".join(self.board), self.turn)
             self.build_buttons()
             await interaction.response.edit_message(view=self)
             await self.update_all_messages()
+
 
 class XOButton(Button):
     def __init__(self, index: int, label: str, style: ButtonStyle):


### PR DESCRIPTION
## Summary
- clean up unused imports
- reformat logic and add black formatting
- fix indentation in the winner logic
- remove leftover imports in game view

## Testing
- `python -m py_compile bot.py game/*.py`
- `flake8 | head` (fails: E302 expected 2 blank lines, E501 line too long, etc.)

------
https://chatgpt.com/codex/tasks/task_e_68425a61a2988327ac3a65aa52899bd0